### PR TITLE
Refactor XML IO interface to allow easy support of other XML libs.

### DIFF
--- a/src/SWIDStruct.cpp
+++ b/src/SWIDStruct.cpp
@@ -23,6 +23,9 @@ void SWIDStruct::applyDefaults() {
 	if (versionScheme.size() == 0) {
 		versionScheme = "multipartnumeric";
 	}
+	if (version.size() == 0) {
+		version = "0.0";
+	}
 }
 
 

--- a/src/SWIDStruct.h
+++ b/src/SWIDStruct.h
@@ -3,8 +3,16 @@
 #include <string>
 #include <vector>
 
+
+/**
+ * SWID Tag Types
+ */
 enum type_id {SWID_TYPE_PRIMARY, SWID_TYPE_CORPUS, SWID_TYPE_PATCH, SWID_TYPE_SUPPLEMENTAL};
 
+
+/**
+ * SWID Entity Roles
+ */
 enum role_id {
 	SWID_ROLE_NONE = 0,
 	SWID_ROLE_AGGREGATOR
@@ -22,9 +30,6 @@ enum role_id {
 
 role_id operator | (role_id a, role_id b);
 role_id operator & (role_id a, role_id b);
-
-
-// enum link_rel_id {SWID_LINK_REL_COMPONENT, SWID_LINK_REL_PATCHES, SWID_LINK_REL_REQUIRES, SWID_LINK_REL_SUPERSEDES, SWID_LINK_REL_SUPPLEMENTAL, SWID_LINK_REL_ANY};
 
 
 class SWIDEntity
@@ -49,19 +54,28 @@ public:
 typedef std::vector<SWIDLink> Links;
 
 
+/**
+ * The SWID Tag as a data structure.
+ */
 class SWIDStruct
 {
 public:
 	SWIDStruct();
 
+	/// Set all empty values to their defaults.
 	void applyDefaults();
 
+	/// Name of the product or component as it would normally be referenced. HARD REQUIREMENT.
 	std::string name;
+	/// Globally unique identifier of the tag. HARD REQUIREMENT.
 	std::string tagId;
+	/// Detailed version of the product. SOFT REQUIREMENT, defaults to "0.0"
 	std::string version;
+	/// Encoding of the version, e.g. "semver", "decimal", "unknown". SOFT REQUIREMENT, defaults to "multipartnumeric"
 	std::string versionScheme;
+	/// Language of the tag in form of W3C-langtag. Automatically inherited to sub-elements. SOFT REQUIREMENT without default.
 	std::string xml_lang;
-	/// Default tag type is "primary"
+	/// OPTIONAL, defaults to SWID_TYPE_PRIMARY.
 	type_id type;
 
 	Entities entities;

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -22,10 +22,16 @@
 
 // TODO: Make a script that inserts and updates the copyright claim in cpp files
 
+#include <sstream>
+
 #include "lib.h"
 
 #include "loader-xerces.h"
 #include "loader-tinyxml.h"
+
+
+using std::ostringstream;
+
 
 XMLReadError::XMLReadError(const std::string & what_arg):std::runtime_error(what_arg) {
 }
@@ -35,11 +41,23 @@ XMLReadError::XMLReadError(const char * what_arg):std::runtime_error(what_arg) {
 }
 
 
-SWIDTagIO::SWIDTagIO() {
+XMLReadError create_read_error(const std::string & filename, const std::string & what_happened) {
+	ostringstream msg;
+	msg << "Error loading from '";
+	msg << filename;
+	msg << "': ";
+	msg << what_happened;
+	return XMLReadError(msg.str());
 }
 
 
-SWIDTagIO::~SWIDTagIO() {
+XMLReadError create_save_error(const std::string & filename, const std::string & what_happened) {
+	ostringstream msg;
+	msg << "Error saving to '";
+	msg << filename;
+	msg << "': ";
+	msg << what_happened;
+	return XMLReadError(msg.str());
 }
 
 

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -33,31 +33,36 @@
 using std::ostringstream;
 
 
-XMLReadError::XMLReadError(const std::string & what_arg):std::runtime_error(what_arg) {
+XMLIOError::XMLIOError(const std::string & what_arg):std::runtime_error(what_arg) {
 }
 
 
-XMLReadError::XMLReadError(const char * what_arg):std::runtime_error(what_arg) {
+XMLIOError::XMLIOError(const char * what_arg):std::runtime_error(what_arg) {
 }
 
 
-XMLReadError create_read_error(const std::string & filename, const std::string & what_happened) {
+static XMLIOError create_xml_io_error(const std::string & filename, const std::string & error_intro, const std::string & what_happened) {
 	ostringstream msg;
-	msg << "Error loading from '";
+	msg << error_intro;
+	msg << " '";
 	msg << filename;
 	msg << "': ";
 	msg << what_happened;
-	return XMLReadError(msg.str());
+	return XMLIOError(msg.str());
 }
 
 
-XMLReadError create_save_error(const std::string & filename, const std::string & what_happened) {
-	ostringstream msg;
-	msg << "Error saving to '";
-	msg << filename;
-	msg << "': ";
-	msg << what_happened;
-	return XMLReadError(msg.str());
+XMLIOError create_read_error(const std::string & filename, const std::string & what_happened) {
+	return create_xml_io_error(filename, "Could not load from", what_happened);
+}
+
+
+XMLIOError create_save_error(const std::string & filename, const std::string & what_happened) {
+	return create_xml_io_error(filename, "Could not save to", what_happened);
+}
+
+
+SWIDTagIO::~SWIDTagIO() {
 }
 
 

--- a/src/lib.h
+++ b/src/lib.h
@@ -7,21 +7,23 @@
 
 
 
-class XMLReadError : public std::runtime_error
+class XMLIOError : public std::runtime_error
 {
 public:
-	explicit XMLReadError(const std::string & what_arg);
-	explicit XMLReadError(const char * what_arg);
+	explicit XMLIOError(const std::string & what_arg);
+	explicit XMLIOError(const char * what_arg);
 };
 
 
-XMLReadError create_read_error(const std::string & filename, const std::string & what_happened);
-XMLReadError create_save_error(const std::string & filename, const std::string & what_happened);
+XMLIOError create_read_error(const std::string & filename, const std::string & what_happened);
+XMLIOError create_save_error(const std::string & filename, const std::string & what_happened);
 
 
 class SWIDTagIO
 {
 public:
+	virtual ~SWIDTagIO();
+
 	/**
 	 * Get a SWIDStruct instance from an XML file.
 	 */

--- a/src/lib.h
+++ b/src/lib.h
@@ -6,6 +6,7 @@
 #include "SWIDStruct.h"
 
 
+
 class XMLReadError : public std::runtime_error
 {
 public:
@@ -14,14 +15,30 @@ public:
 };
 
 
+XMLReadError create_read_error(const std::string & filename, const std::string & what_happened);
+XMLReadError create_save_error(const std::string & filename, const std::string & what_happened);
+
+
 class SWIDTagIO
 {
 public:
-	SWIDTagIO();
-	virtual ~SWIDTagIO();
+	/**
+	 * Get a SWIDStruct instance from an XML file.
+	 */
 	virtual SWIDStruct load(const std::string & filename) = 0;
+	/**
+	 * Save a SWIDStruct instance to an XML file.
+	 */
 	virtual void save(const std::string & filename, const SWIDStruct & what) = 0;
 };
 
 
+/**
+ * Get pointer to a SWIDTagIO instance.
+ *
+ * Remember to free it using `delete`!
+ *
+ * Args:
+ *  - type: The type string. May be one of "xerces", "tinyxml"
+ */
 SWIDTagIO * get_a_swidtagio(const char * type);

--- a/src/loader-generic.cpp
+++ b/src/loader-generic.cpp
@@ -1,0 +1,100 @@
+#include "loader-generic.h"
+#include "Translator.h"
+
+
+template<class el_t>
+SWIDStruct XMLIO<el_t>::load(const std::string & filename) {
+	el_t * pRoot = readRoot(filename);
+
+	auto ret = SWIDStruct();
+
+	ret.name = extractAttrValue(pRoot, "name");
+	ret.tagId = extractAttrValue(pRoot, "tagId");
+	ret.version = extractAttrValue(pRoot, "version");
+	ret.versionScheme = extractAttrValue(pRoot, "versionScheme");
+	ret.xml_lang = extractAttrValue(pRoot, "xml:lang");
+
+	ret.type = determine_type_id(
+		extractAttrValue(pRoot, "corpus").c_str(),
+		extractAttrValue(pRoot, "patch").c_str(),
+		extractAttrValue(pRoot, "supplemental").c_str());
+
+	auto subelements = subElementsOf(pRoot);
+
+	if (subelements.find(SWID_ELEMENT_ENTITY) != subelements.end()) {
+		addEntities(ret, subelements[SWID_ELEMENT_ENTITY]);
+	}
+
+	if (subelements.find(SWID_ELEMENT_LINK) != subelements.end()) {
+		addLinks(ret, subelements[SWID_ELEMENT_LINK]);
+	}
+
+	return ret;
+}
+
+
+template<class el_t>
+void XMLIO<el_t>::addEntities(SWIDStruct & subject, const std::vector<el_t *> & entities) {
+	std::string role;
+	for (auto it = entities.begin(); it != entities.end(); it++) {
+		auto entity = SWIDEntity();
+		entity.name = extractAttrValue(* it, "name");
+		entity.regid = extractAttrValue(* it, "regid");
+		role = extractAttrValue(* it, "role");
+		entity.role = Role(role).RoleAsId();
+		subject.entities.push_back(entity);
+	}
+}
+
+
+template<class el_t>
+void XMLIO<el_t>::addLinks(SWIDStruct & subject, const std::vector<el_t *> & links) {
+	for (auto it = links.begin(); it != links.end(); it++) {
+		auto link = SWIDLink();
+		link.href = extractAttrValue(* it, "href");
+		link.rel = extractAttrValue(* it, "rel");
+		subject.links.push_back(link);
+	}
+}
+
+
+template<class el_t>
+void XMLIO<el_t>::save(const std::string & filename, const SWIDStruct & what) {
+	el_t * pRoot = createRoot();
+
+	setAttrValue(pRoot, "name", what.name);
+	setAttrValue(pRoot, "tagId", what.tagId);
+	setAttrValue(pRoot, "version", what.version);
+	setAttrValue(pRoot, "versionScheme", what.versionScheme);
+	setAttrValue(pRoot, "xml:lang", what.xml_lang);
+
+	std::string corpus, patch, supplemental;
+	set_strings_to_match_type(what.type, corpus, patch, supplemental);
+	setAttrValue(pRoot, "corpus", corpus);
+	setAttrValue(pRoot, "patch", patch);
+	setAttrValue(pRoot, "supplemental", supplemental);
+
+	for (auto it = what.entities.begin(); it != what.entities.end(); it++) {
+		el_t * el = createSubElement(pRoot, SWID_ELEMENT_ENTITY);;
+		setAttrValue(el, "name", it->name);
+		setAttrValue(el, "regid", it->regid);
+		setAttrValue(el, "role", Role(it->role).RoleAsString());
+	}
+
+	for (auto it = what.links.begin(); it != what.links.end(); it++) {
+		el_t * el = createSubElement(pRoot, SWID_ELEMENT_LINK);;
+		setAttrValue(el, "href", it->href);
+		setAttrValue(el, "rel", it->rel);
+	}
+	saveToFile(filename);
+}
+
+
+template<class el_t>
+std::map<int, std::vector<el_t *> > XMLIO<el_t>::createEmptyMap() const {
+	std::map<int, std::vector<el_t *> > result;
+	for (int i = 0; i < TOTAL_SWID_ELEMENT_COUNT; i++) {
+		result[i] = std::vector<el_t *>();
+	}
+	return result;
+}

--- a/src/loader-generic.cpp
+++ b/src/loader-generic.cpp
@@ -3,6 +3,11 @@
 
 
 template<class el_t>
+XMLIO<el_t>::~XMLIO() {
+}
+
+
+template<class el_t>
 SWIDStruct XMLIO<el_t>::load(const std::string & filename) {
 	el_t * pRoot = readRoot(filename);
 

--- a/src/loader-generic.cpp
+++ b/src/loader-generic.cpp
@@ -80,14 +80,14 @@ void XMLIO<el_t>::save(const std::string & filename, const SWIDStruct & what) {
 	setAttrValue(pRoot, "supplemental", supplemental);
 
 	for (auto it = what.entities.begin(); it != what.entities.end(); it++) {
-		el_t * el = createSubElement(pRoot, SWID_ELEMENT_ENTITY);;
+		el_t * el = createSubElement(pRoot, SWID_ELEMENT_ENTITY);
 		setAttrValue(el, "name", it->name);
 		setAttrValue(el, "regid", it->regid);
 		setAttrValue(el, "role", Role(it->role).RoleAsString());
 	}
 
 	for (auto it = what.links.begin(); it != what.links.end(); it++) {
-		el_t * el = createSubElement(pRoot, SWID_ELEMENT_LINK);;
+		el_t * el = createSubElement(pRoot, SWID_ELEMENT_LINK);
 		setAttrValue(el, "href", it->href);
 		setAttrValue(el, "rel", it->rel);
 	}

--- a/src/loader-generic.h
+++ b/src/loader-generic.h
@@ -13,6 +13,8 @@ template<class el_t>
 class XMLIO : public SWIDTagIO
 {
 public:
+	virtual ~XMLIO() override;
+
 	virtual SWIDStruct load(const std::string & filename) override;
 	virtual void save(const std::string & filename, const SWIDStruct & what) override;
 

--- a/src/loader-generic.h
+++ b/src/loader-generic.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <map>
+#include "lib.h"
+
+#define SWID_NS "http://standards.iso.org/iso/19770/-2/2015/schema.xsd"
+
+
+enum {SWID_ELEMENT_ENTITY = 0, SWID_ELEMENT_LINK, TOTAL_SWID_ELEMENT_COUNT};
+
+
+template<class el_t>
+class XMLIO : public SWIDTagIO
+{
+public:
+	virtual SWIDStruct load(const std::string & filename) override;
+	virtual void save(const std::string & filename, const SWIDStruct & what) override;
+
+protected:
+	virtual void setAttrValue(el_t * el, const char * name, const std::string & value) = 0;
+	virtual std::string extractAttrValue(el_t * el, const char * name) const = 0;
+	virtual std::map<int, std::vector<el_t *> > subElementsOf(el_t * el) const = 0;
+	virtual el_t * createRoot() = 0;
+	virtual el_t * readRoot(const std::string & filename) = 0;
+	virtual el_t * createSubElement(el_t * parent, int element_type) = 0;
+	virtual void saveToFile(const std::string & filename) = 0;
+
+	std::map<int, std::vector<el_t *> > createEmptyMap() const;
+private:
+	void addEntities(SWIDStruct & subject, const std::vector<el_t *> & entities);
+	void addLinks(SWIDStruct & subject, const std::vector<el_t *> & links);
+};

--- a/src/loader-tinyxml.cpp
+++ b/src/loader-tinyxml.cpp
@@ -1,32 +1,84 @@
 #include "loader-tinyxml.h"
 #include "Translator.h"
 
+#include "loader-generic.cpp"
 
 using std::string;
 
 
-TiXMLSWIDTagIO::TiXMLSWIDTagIO():SWIDTagIO() {
+TiXMLSWIDTagIO::TiXMLSWIDTagIO() {
+	element_strings[SWID_ELEMENT_ENTITY] = "Entity";
+	element_strings[SWID_ELEMENT_LINK] = "Link";
 }
 
 
-TiXMLSWIDTagIO::~TiXMLSWIDTagIO() {
+void TiXMLSWIDTagIO::setAttrValue(TiXmlElement * el, const char * name, const string & value) {
+	el->SetAttribute(name, value);
+}
+
+
+string TiXMLSWIDTagIO::extractAttrValue(TiXmlElement * el, const char * name) const {
+	return el->Attribute(name);
+}
+
+
+std::map<int, std::vector<TiXmlElement *> > TiXMLSWIDTagIO::subElementsOf(TiXmlElement * el) const {
+	auto result = createEmptyMap();
+	for (auto it = el->FirstChildElement(); it != NULL; it = it->NextSiblingElement()) {
+		for (int i = 0; i < TOTAL_SWID_ELEMENT_COUNT; i++) {
+			if (strcmp(it->Value(), element_strings[i]) == 0) {
+				result[i].push_back(it);
+				continue;
+			}
+		}
+	}
+	return result;
+}
+
+
+TiXmlElement * TiXMLSWIDTagIO::createRoot() {
+	doc = TiXmlDocument();;
+
+	auto * decl = new TiXmlDeclaration( "1.0", "", "" );
+	doc.LinkEndChild( decl );
+	auto * pRoot = new TiXmlElement("SoftwareIdentity");
+	setAttrValue(pRoot, "xmlns", SWID_NS);
+	doc.LinkEndChild( pRoot );
+	return pRoot;
+}
+
+
+TiXmlElement * TiXMLSWIDTagIO::readRoot(const std::string & filename) {
+	doc = TiXmlDocument();;
+
+	auto result = doc.LoadFile(filename.c_str());
+	if (! result) {
+		throw create_read_error(filename, doc.ErrorDesc());
+	}
+	return doc.RootElement();
+}
+
+
+TiXmlElement * TiXMLSWIDTagIO::createSubElement(TiXmlElement * parent, int element_type) {
+	auto * entity_el = new TiXmlElement(element_strings[element_type]);
+	parent->LinkEndChild(entity_el);
+	return entity_el;
+}
+
+
+void TiXMLSWIDTagIO::saveToFile(const std::string & filename) {
+	auto result = doc.SaveFile(filename.c_str());
+	if (! result) {
+		throw create_save_error(filename, doc.ErrorDesc());
+	}
 }
 
 
 /*
-void add_entity(TiXMLNode * entity_node, std::vector<SWIDEntity>) {
-}
-*/
-
-
 SWIDStruct TiXMLSWIDTagIO::load(const string & filename) {
 	TiXmlDocument doc;
 
-	auto result = doc.LoadFile(filename.c_str());
 
-	if (! result) {
-		throw XMLReadError(doc.ErrorDesc());
-	}
 
 	auto ret = SWIDStruct();
 	auto * pRoot = doc.RootElement();
@@ -61,8 +113,6 @@ SWIDStruct TiXMLSWIDTagIO::load(const string & filename) {
 
 void TiXMLSWIDTagIO::save(const string & filename, const SWIDStruct & what) {
 	TiXmlDocument doc;
-	auto * decl = new TiXmlDeclaration( "1.0", "", "" );
-	doc.LinkEndChild( decl );
 
 	auto * pRoot = new TiXmlElement("SoftwareIdentity");
 
@@ -95,8 +145,11 @@ void TiXMLSWIDTagIO::save(const string & filename, const SWIDStruct & what) {
 
 	doc.LinkEndChild(pRoot);
 
+	auto * decl = new TiXmlDeclaration( "1.0", "", "" );
+	doc.LinkFirstChild( decl );
 	auto result = doc.SaveFile(filename.c_str());
 	if (! result) {
 		throw XMLReadError(doc.ErrorDesc());
 	}
 }
+*/

--- a/src/loader-tinyxml.cpp
+++ b/src/loader-tinyxml.cpp
@@ -24,11 +24,11 @@ string TiXMLSWIDTagIO::extractAttrValue(TiXmlElement * el, const char * name) co
 
 std::map<int, std::vector<TiXmlElement *> > TiXMLSWIDTagIO::subElementsOf(TiXmlElement * el) const {
 	auto result = createEmptyMap();
-	for (auto it = el->FirstChildElement(); it != NULL; it = it->NextSiblingElement()) {
+	for (auto * sub_el = el->FirstChildElement(); sub_el != NULL; sub_el = sub_el->NextSiblingElement()) {
 		for (int i = 0; i < TOTAL_SWID_ELEMENT_COUNT; i++) {
-			if (strcmp(it->Value(), element_strings[i]) == 0) {
-				result[i].push_back(it);
-				continue;
+			if (strcmp(sub_el->Value(), element_strings[i]) == 0) {
+				result[i].push_back(sub_el);
+				break;
 			}
 		}
 	}
@@ -37,7 +37,7 @@ std::map<int, std::vector<TiXmlElement *> > TiXMLSWIDTagIO::subElementsOf(TiXmlE
 
 
 TiXmlElement * TiXMLSWIDTagIO::createRoot() {
-	doc = TiXmlDocument();;
+	doc = TiXmlDocument();
 
 	auto * decl = new TiXmlDeclaration( "1.0", "", "" );
 	doc.LinkEndChild( decl );
@@ -49,7 +49,7 @@ TiXmlElement * TiXMLSWIDTagIO::createRoot() {
 
 
 TiXmlElement * TiXMLSWIDTagIO::readRoot(const std::string & filename) {
-	doc = TiXmlDocument();;
+	doc = TiXmlDocument();
 
 	auto result = doc.LoadFile(filename.c_str());
 	if (! result) {
@@ -72,84 +72,3 @@ void TiXMLSWIDTagIO::saveToFile(const std::string & filename) {
 		throw create_save_error(filename, doc.ErrorDesc());
 	}
 }
-
-
-/*
-SWIDStruct TiXMLSWIDTagIO::load(const string & filename) {
-	TiXmlDocument doc;
-
-
-
-	auto ret = SWIDStruct();
-	auto * pRoot = doc.RootElement();
-
-	ret.name = pRoot->Attribute("name");
-	ret.tagId = pRoot->Attribute("tagId");
-	ret.version = pRoot->Attribute("version");
-	ret.versionScheme = pRoot->Attribute("versionScheme");
-	ret.xml_lang = pRoot->Attribute("xml:lang");
-
-	ret.type = determine_type_id(
-		pRoot->Attribute("corpus"), pRoot->Attribute("patch"), pRoot->Attribute("supplemental"));
-
-	auto entity = SWIDEntity();
-	for (auto it = pRoot->FirstChildElement("Entity"); it != NULL; it = it->NextSiblingElement("Entity")) {
-		entity.name = it->Attribute("name");
-		entity.regid = it->Attribute("regid");
-		const char * role = it->Attribute("role");
-		entity.role = Role(role).RoleAsId();
-		ret.entities.push_back(entity);
-	}
-	auto link = SWIDLink();
-	for (auto it = pRoot->FirstChildElement("Link"); it != NULL; it = it->NextSiblingElement("Link")) {
-		link.href = it->Attribute("href");
-		link.rel = it->Attribute("rel");
-		ret.links.push_back(link);
-	}
-
-	return ret;
-}
-
-
-void TiXMLSWIDTagIO::save(const string & filename, const SWIDStruct & what) {
-	TiXmlDocument doc;
-
-	auto * pRoot = new TiXmlElement("SoftwareIdentity");
-
-	pRoot->SetAttribute("name", what.name.c_str());
-	pRoot->SetAttribute("tagId", what.tagId.c_str());
-	pRoot->SetAttribute("version", what.version.c_str());
-	pRoot->SetAttribute("versionScheme", what.versionScheme.c_str());
-	pRoot->SetAttribute("xml:lang", what.xml_lang.c_str());
-
-	string corpus, patch, supplemental;
-	set_strings_to_match_type(what.type, corpus, patch, supplemental);
-	pRoot->SetAttribute("corpus", corpus);
-	pRoot->SetAttribute("patch", patch);
-	pRoot->SetAttribute("supplemental", supplemental);
-
-	for (auto it = what.entities.begin(); it != what.entities.end(); it++) {
-		auto * entity_el = new TiXmlElement("Entity");
-		entity_el->SetAttribute("name", it->name.c_str());
-		entity_el->SetAttribute("regid", it->regid.c_str());
-		entity_el->SetAttribute("role", Role(it->role).RoleAsString());
-		pRoot->LinkEndChild(entity_el);
-	}
-
-	for (auto it = what.links.begin(); it != what.links.end(); it++) {
-		auto * link_el = new TiXmlElement("Link");
-		link_el->SetAttribute("href", it->href.c_str());
-		link_el->SetAttribute("rel", it->rel.c_str());
-		pRoot->LinkEndChild(link_el);
-	}
-
-	doc.LinkEndChild(pRoot);
-
-	auto * decl = new TiXmlDeclaration( "1.0", "", "" );
-	doc.LinkFirstChild( decl );
-	auto result = doc.SaveFile(filename.c_str());
-	if (! result) {
-		throw XMLReadError(doc.ErrorDesc());
-	}
-}
-*/

--- a/src/loader-tinyxml.h
+++ b/src/loader-tinyxml.h
@@ -4,12 +4,23 @@
 
 #include <tinyxml.h>
 
+#include "loader-generic.h"
 
-class TiXMLSWIDTagIO: public SWIDTagIO
+
+class TiXMLSWIDTagIO : public XMLIO<TiXmlElement>
 {
 public:
 	TiXMLSWIDTagIO();
-	virtual ~TiXMLSWIDTagIO() override;
-	virtual SWIDStruct load(const std::string & filename) override;
-	virtual void save(const std::string & filename, const SWIDStruct & what) override;
+private:
+	virtual void setAttrValue(TiXmlElement * el, const char * name, const std::string & value);
+	virtual std::string extractAttrValue(TiXmlElement * el, const char * name) const;
+	virtual std::map<int, std::vector<TiXmlElement *> > subElementsOf(TiXmlElement * el) const;
+	virtual TiXmlElement * createRoot();
+	virtual TiXmlElement * readRoot(const std::string & filename);
+	virtual TiXmlElement * createSubElement(TiXmlElement * parent, int element_type);
+	virtual void saveToFile(const std::string & filename);
+
+	const char * element_strings[TOTAL_SWID_ELEMENT_COUNT];
+
+	TiXmlDocument doc;
 };

--- a/src/loader-tinyxml.h
+++ b/src/loader-tinyxml.h
@@ -12,13 +12,13 @@ class TiXMLSWIDTagIO : public XMLIO<TiXmlElement>
 public:
 	TiXMLSWIDTagIO();
 private:
-	virtual void setAttrValue(TiXmlElement * el, const char * name, const std::string & value);
-	virtual std::string extractAttrValue(TiXmlElement * el, const char * name) const;
-	virtual std::map<int, std::vector<TiXmlElement *> > subElementsOf(TiXmlElement * el) const;
-	virtual TiXmlElement * createRoot();
-	virtual TiXmlElement * readRoot(const std::string & filename);
-	virtual TiXmlElement * createSubElement(TiXmlElement * parent, int element_type);
-	virtual void saveToFile(const std::string & filename);
+	virtual void setAttrValue(TiXmlElement * el, const char * name, const std::string & value) override;
+	virtual std::string extractAttrValue(TiXmlElement * el, const char * name) const override;
+	virtual std::map<int, std::vector<TiXmlElement *> > subElementsOf(TiXmlElement * el) const override;
+	virtual TiXmlElement * createRoot() override;
+	virtual TiXmlElement * readRoot(const std::string & filename) override;
+	virtual TiXmlElement * createSubElement(TiXmlElement * parent, int element_type) override;
+	virtual void saveToFile(const std::string & filename) override;
 
 	const char * element_strings[TOTAL_SWID_ELEMENT_COUNT];
 

--- a/src/loader-xerces.cpp
+++ b/src/loader-xerces.cpp
@@ -140,11 +140,11 @@ void XercesSWIDTagIO::createParser() {
 
 std::map<int, std::vector<DOMElement *> > XercesSWIDTagIO::subElementsOf(DOMElement * el) const {
 	auto result = createEmptyMap();
-	for (auto it = el->getFirstElementChild(); it != NULL; it = it->getNextElementSibling()) {
-		if (XMLString::compareIString(it->getTagName(), xmlch_entity) == 0) {
-			result[SWID_ELEMENT_ENTITY].push_back(it);
-		} else if (XMLString::compareIString(it->getTagName(), xmlch_link) == 0) {
-			result[SWID_ELEMENT_LINK].push_back(it);
+	for (auto * sub_el = el->getFirstElementChild(); sub_el != NULL; sub_el = sub_el->getNextElementSibling()) {
+		if (XMLString::compareIString(sub_el->getTagName(), xmlch_entity) == 0) {
+			result[SWID_ELEMENT_ENTITY].push_back(sub_el);
+		} else if (XMLString::compareIString(sub_el->getTagName(), xmlch_link) == 0) {
+			result[SWID_ELEMENT_LINK].push_back(sub_el);
 		}
 	}
 	return result;

--- a/src/loader-xerces.h
+++ b/src/loader-xerces.h
@@ -12,7 +12,8 @@ class XercesSWIDTagIO : public XMLIO<xercesc::DOMElement>
 {
 public:
 	XercesSWIDTagIO();
-	virtual ~XercesSWIDTagIO();
+	virtual ~XercesSWIDTagIO() override;
+
 	virtual SWIDStruct load(const std::string & filename) override;
 	// virtual void save(const std::string & filename, const SWIDStruct & what) override;
 
@@ -20,19 +21,19 @@ private:
 	void deleteParser();
 	void createParser();
 
-	void setAttrValue(xercesc::DOMElement * el, const char * name, const std::string & value);
-	std::string extractAttrValue(xercesc::DOMElement * el, const char * name) const;
-	std::map<int, std::vector<xercesc::DOMElement *> > subElementsOf(xercesc::DOMElement * el) const;
+	void setAttrValue(xercesc::DOMElement * el, const char * name, const std::string & value) override;
+	std::string extractAttrValue(xercesc::DOMElement * el, const char * name) const override;
+	std::map<int, std::vector<xercesc::DOMElement *> > subElementsOf(xercesc::DOMElement * el) const override;
 
-	xercesc::DOMElement * createRoot();
-	xercesc::DOMElement * readRoot(const std::string & filename);
+	xercesc::DOMElement * createRoot() override;
+	xercesc::DOMElement * readRoot(const std::string & filename) override;
 
 	xercesc::XercesDOMParser * parser;
 	xercesc::ErrorHandler * errHandler;
 	xercesc::DOMDocument * doc;
 
-	xercesc::DOMElement * createSubElement(xercesc::DOMElement * root, int element_type);
-	virtual void saveToFile(const std::string & filename);
+	xercesc::DOMElement * createSubElement(xercesc::DOMElement * root, int element_type) override;
+	virtual void saveToFile(const std::string & filename) override;
 
 	XMLCh * element_strings[TOTAL_SWID_ELEMENT_COUNT];
 	XMLCh * swid_ns;

--- a/src/loader-xerces.h
+++ b/src/loader-xerces.h
@@ -1,28 +1,40 @@
 #pragma once
 
+#include <map>
+
 #include "lib.h"
+#include "loader-generic.h"
 
 #include <xercesc/parsers/XercesDOMParser.hpp>
 
 
-class XercesSWIDTagIO: public SWIDTagIO
+class XercesSWIDTagIO : public XMLIO<xercesc::DOMElement>
 {
 public:
 	XercesSWIDTagIO();
-	virtual ~XercesSWIDTagIO() override;
+	virtual ~XercesSWIDTagIO();
 	virtual SWIDStruct load(const std::string & filename) override;
-	virtual void save(const std::string & filename, const SWIDStruct & what) override;
+	// virtual void save(const std::string & filename, const SWIDStruct & what) override;
 
 private:
 	void deleteParser();
 	void createParser();
 
 	void setAttrValue(xercesc::DOMElement * el, const char * name, const std::string & value);
-	std::string extractAttrValue(xercesc::DOMElement * el, const char * name);
+	std::string extractAttrValue(xercesc::DOMElement * el, const char * name) const;
+	std::map<int, std::vector<xercesc::DOMElement *> > subElementsOf(xercesc::DOMElement * el) const;
+
+	xercesc::DOMElement * createRoot();
+	xercesc::DOMElement * readRoot(const std::string & filename);
 
 	xercesc::XercesDOMParser * parser;
 	xercesc::ErrorHandler * errHandler;
+	xercesc::DOMDocument * doc;
 
+	xercesc::DOMElement * createSubElement(xercesc::DOMElement * root, int element_type);
+	virtual void saveToFile(const std::string & filename);
+
+	XMLCh * element_strings[TOTAL_SWID_ELEMENT_COUNT];
 	XMLCh * swid_ns;
 	XMLCh * xmlch_entity;
 	XMLCh * xmlch_link;

--- a/test/unit/test.cpp
+++ b/test/unit/test.cpp
@@ -49,8 +49,8 @@ void check(string parser_name) {
 		CHECK_THROWS( loader->load("") );
 		try {
 			loader->load("");
-		} catch (const XMLReadError & toCatch) {
-			regex good_msg_start("Error loading from '':.*");
+		} catch (const XMLIOError & toCatch) {
+			regex good_msg_start("Could not load from '':.*");
 			REQUIRE(regex_match(toCatch.what(), good_msg_start));
 		}
 	}


### PR DESCRIPTION
TinyXML can't do advanced features, and Xerces is very difficult to use. LibXML++ seems to be pretty good, but has lots of dependencies.
This change allows easy support of new XML IO libraries into libswid.